### PR TITLE
Fixed an issue where a function overwrite caused a php warning becaus…

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,7 +7,8 @@ All important changes to this plugin will be documented in this file.
 - Adjusted plugin to work with ilias 6. MUMIE Task no longer supports Ilias versions prior to 6.0
 
 ### Fixed
-- Fixed an error in MUMIE server form, where whitespace around the URL prefix could cause an error 
+- Fixed an error in MUMIE server form, where whitespace around the URL prefix could cause an error
+- Fixed a warning during verification of SSO attempts that appeared in the server logs
 
 ## [v1.2.0] - 2021-04-29
 ### Fixed

--- a/classes/class.ilMumieTaskInitialisation.php
+++ b/classes/class.ilMumieTaskInitialisation.php
@@ -16,7 +16,7 @@ require_once("Services/Init/classes/class.ilInitialisation.php");
  */
 class ilMumieTaskInitialisation extends ilInitialisation
 {
-    public static function initILIAS($clientId)
+    public static function init($clientId)
     {
         define('CLIENT_ID', $clientId);
         parent::initILIAS();

--- a/verifyToken.php
+++ b/verifyToken.php
@@ -26,7 +26,7 @@ require_once "Services/Context/classes/class.ilContext.php";
 ilContext::init(ilContext::CONTEXT_REST);
 
 require_once(__DIR__ . "/classes/class.ilMumieTaskInitialisation.php");
-ilMumieTaskInitialisation::initILIAS($_REQUEST['clientId']);
+ilMumieTaskInitialisation::init($_REQUEST['clientId']);
 
 //once the global exists we can verify the token
 


### PR DESCRIPTION
…e it had a different signature.